### PR TITLE
Tweaked TU Darmstadt ShibHttpClient to deal with HTTP tunnel proxies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.2.3</version>
+			<version>4.3</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>

--- a/src/main/java/de/tudarmstadt/ukp/shibhttpclient/ShibHttpClient.java
+++ b/src/main/java/de/tudarmstadt/ukp/shibhttpclient/ShibHttpClient.java
@@ -158,10 +158,11 @@ public class ShibHttpClient
 		RequestConfig globalRequestConfig = RequestConfig.custom()
 											.setCookieSpec(CookieSpecs.BROWSER_COMPATIBILITY)
 											.build();
-		
 
-		// we're using the basic CloseableHttpClient (DefaultHttpClient is deprecated), so we need to set things explicitly
+		// Add the ECP/PAOS headers - needs to be added first so the cookie we get from
+		// the authentication can be handled by the RequestAddCookies interceptor later
 		HttpRequestPreprocessor preProcessor = new HttpRequestPreprocessor();
+		// Automatically log into IdP if SP requests this
 		HttpRequestPostprocessor postProcessor = new HttpRequestPostprocessor();
 		
 		// build our client
@@ -174,6 +175,7 @@ public class ShibHttpClient
 				// Add the ECP/PAOS headers - needs to be added first so the cookie we get from
 				// the authentication can be handled by the RequestAddCookies interceptor later
 				.addInterceptorFirst(preProcessor)
+				// Automatically log into IdP if SP requests this
 				.addInterceptorFirst(postProcessor)
 				.build();
 

--- a/src/main/java/de/tudarmstadt/ukp/shibhttpclient/ShibHttpClient.java
+++ b/src/main/java/de/tudarmstadt/ukp/shibhttpclient/ShibHttpClient.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
+
 package de.tudarmstadt.ukp.shibhttpclient;
 
 import static de.tudarmstadt.ukp.shibhttpclient.Utils.getAnyCertManager;
@@ -46,7 +47,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.params.CookiePolicy;
 import org.apache.http.client.params.HttpClientParams;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.scheme.Scheme;
@@ -59,7 +59,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.RequestWrapper;
 import org.apache.http.impl.conn.PoolingClientConnectionManager;
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
-import org.apache.http.message.BasicHttpRequest;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;

--- a/src/main/java/de/tudarmstadt/ukp/shibhttpclient/ShibHttpClient.java
+++ b/src/main/java/de/tudarmstadt/ukp/shibhttpclient/ShibHttpClient.java
@@ -86,13 +86,13 @@ import org.opensaml.xml.util.Base64;
  * authentication request, a login is performed before the original request is executed.
  */
 public class ShibHttpClient
-    implements HttpClient
+implements HttpClient
 {
     private final Log log = LogFactory.getLog(getClass());
 
     private static final String AUTH_IN_PROGRESS = ShibHttpClient.class.getName()
             + ".AUTH_IN_PROGRESS";
-    
+
     private static final String MIME_TYPE_PAOS = "application/vnd.paos+xml";
 
 //    private static final QName E_PAOS_REQUEST = new QName(SAMLConstants.PAOS_NS, "Request");
@@ -151,33 +151,33 @@ public class ShibHttpClient
         connMgr.setDefaultMaxPerRoute(5);
         
         // retrieve the JVM parameters for proxy state (do we have a proxy?)
-		SystemDefaultRoutePlanner sdrp = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
+        SystemDefaultRoutePlanner sdrp = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
 
-		// The client needs to remember the auth cookie
-		cookieStore = new BasicCookieStore();
-		RequestConfig globalRequestConfig = RequestConfig.custom()
-											.setCookieSpec(CookieSpecs.BROWSER_COMPATIBILITY)
-											.build();
+        // The client needs to remember the auth cookie
+        cookieStore = new BasicCookieStore();
+        RequestConfig globalRequestConfig = RequestConfig.custom()
+                .setCookieSpec(CookieSpecs.BROWSER_COMPATIBILITY)
+                .build();
 
-		// Add the ECP/PAOS headers - needs to be added first so the cookie we get from
-		// the authentication can be handled by the RequestAddCookies interceptor later
-		HttpRequestPreprocessor preProcessor = new HttpRequestPreprocessor();
-		// Automatically log into IdP if SP requests this
-		HttpRequestPostprocessor postProcessor = new HttpRequestPostprocessor();
-		
-		// build our client
-		client = HttpClients.custom()
-				// use a proxy if one is specified for the JVM
-				.setRoutePlanner(sdrp) 
-				// The client needs to remember the auth cookie
-				.setDefaultRequestConfig(globalRequestConfig) 
-				.setDefaultCookieStore(cookieStore)
-				// Add the ECP/PAOS headers - needs to be added first so the cookie we get from
-				// the authentication can be handled by the RequestAddCookies interceptor later
-				.addInterceptorFirst(preProcessor)
-				// Automatically log into IdP if SP requests this
-				.addInterceptorFirst(postProcessor)
-				.build();
+        // Add the ECP/PAOS headers - needs to be added first so the cookie we get from
+        // the authentication can be handled by the RequestAddCookies interceptor later
+        HttpRequestPreprocessor preProcessor = new HttpRequestPreprocessor();
+        // Automatically log into IdP if SP requests this
+        HttpRequestPostprocessor postProcessor = new HttpRequestPostprocessor();
+
+        // build our client
+        client = HttpClients.custom()
+                // use a proxy if one is specified for the JVM
+                .setRoutePlanner(sdrp)
+                // The client needs to remember the auth cookie
+                .setDefaultRequestConfig(globalRequestConfig)
+                .setDefaultCookieStore(cookieStore)
+                // Add the ECP/PAOS headers - needs to be added first so the cookie we get from
+                // the authentication can be handled by the RequestAddCookies interceptor later
+                .addInterceptorFirst(preProcessor)
+                // Automatically log into IdP if SP requests this
+                .addInterceptorFirst(postProcessor)
+                .build();
 
         parserPool = new BasicParserPool();
         parserPool.setNamespaceAware(true);
@@ -280,7 +280,7 @@ public class ShibHttpClient
                 throws HttpException, IOException
         {
             if (req.getRequestLine().getMethod() == "CONNECT") {
-            	log.trace("Received CONNECT -- Likely to be a proxy request. Skipping pre-processor");
+                log.trace("Received CONNECT -- Likely to be a proxy request. Skipping pre-processor");
                 return;
             }
 
@@ -307,7 +307,7 @@ public class ShibHttpClient
                     log.trace(c.toString());
                 }
                 log.trace("Knocked");
-           }
+            }
         }
     }
 
@@ -322,25 +322,25 @@ public class ShibHttpClient
         public void process(HttpResponse res, HttpContext ctx)
             throws HttpException, IOException
         {
-        	HttpRequest originalRequest;
-        	// check for RequestWrapper objects, retrieve the original request
-    		if (ctx.getAttribute("http.request") instanceof RequestWrapper) { // does not forward request to original
+            HttpRequest originalRequest;
+            // check for RequestWrapper objects, retrieve the original request
+            if (ctx.getAttribute("http.request") instanceof RequestWrapper) { // does not forward request to original
                 log.trace("RequestWrapper found");
-    			originalRequest = (HttpRequest) ((RequestWrapper) ctx.getAttribute("http.request")).getOriginal();
-    		}
-    		else {  // use a basic HttpRequest because BasicHttpRequest objects cannot be recast to HttpUriRequest objects
-    			originalRequest = (HttpRequest) ctx.getAttribute("http.request");
-    		}
+                originalRequest = (HttpRequest) ((RequestWrapper) ctx.getAttribute("http.request")).getOriginal();
+            }
+            else {  // use a basic HttpRequest because BasicHttpRequest objects cannot be recast to HttpUriRequest objects
+                originalRequest = (HttpRequest) ctx.getAttribute("http.request");
+            }
 
             log.trace("Accessing [" + originalRequest.getRequestLine().getUri() + " "
                     + originalRequest.getRequestLine().getMethod() + "]");
-            
+
             // -- Check if authentication is already in progress ----------------------------------
             if (res.getParams().isParameterTrue(AUTH_IN_PROGRESS)) {
                 log.trace("Authentication in progress -- skipping post processor");
                 return;
             }
-            
+
             // -- Check if authentication is necessary --------------------------------------------
             boolean isSamlSoap = false;
             if (res.getFirstHeader(HEADER_CONTENT_TYPE) != null) {
@@ -354,12 +354,12 @@ public class ShibHttpClient
             }
 
             log.trace("Detected login request");
-            
+
             // -- If the request was a HEAD request, we need to try again using a GET request  ----
             HttpResponse paosResponse = res;
             if (originalRequest.getRequestLine().getMethod() == "HEAD") {
                 log.trace("Original request was a HEAD, restarting authenticiation with GET");
-                
+
                 HttpGet authTriggerRequest = new HttpGet(originalRequest.getRequestLine().getUri());
                 authTriggerRequest.getParams().setBooleanParameter(AUTH_IN_PROGRESS, true);
                 paosResponse = client.execute(authTriggerRequest);
@@ -368,7 +368,7 @@ public class ShibHttpClient
             // -- Parse PAOS response -------------------------------------------------------------
             Envelope initialLoginSoapResponse = (Envelope) unmarshallMessage(parserPool,
                     paosResponse.getEntity().getContent());
-            
+
             // -- Capture relay state (optional) --------------------------------------------------
             RelayState relayState = null;
             if (!initialLoginSoapResponse.getHeader()


### PR DESCRIPTION
- Switched to CloseableHttpClient to gain access to JVM proxy settings
- Switched to HttpRequest (from HttpUriRequest) to cope with BasicHttpRequest objects
- Cleaned up unused classes
- Cleaned up indenting
