### PR TITLE
Only HTTP/1.1 200 OK is an acceptable response for Basic Auth on ECP

### DIFF
--- a/src/main/java/de/tudarmstadt/ukp/shibhttpclient/ShibHttpClient.java
+++ b/src/main/java/de/tudarmstadt/ukp/shibhttpclient/ShibHttpClient.java
@@ -421,8 +421,12 @@ implements HttpClient
             idpLoginRequest.setEntity(new StringEntity(xmlToString(idpLoginSoapRequest)));
             HttpResponse idpLoginResponse = client.execute(idpLoginRequest);
 
-            // -- Handle log-in response tfrom the IdP --------------------------------------------
+            // -- Handle log-in response from the IdP --------------------------------------------
             log.debug("Status: " + idpLoginResponse.getStatusLine());
+            if (idpLoginResponse.getStatusLine().getStatusCode() != 200) {
+                throw new AuthenticationException(idpLoginResponse.getStatusLine().toString());
+            }
+            
             Envelope idpLoginSoapResponse = (Envelope) unmarshallMessage(parserPool,
                     idpLoginResponse.getEntity().getContent());
             EntityUtils.consume(idpLoginResponse.getEntity());


### PR DESCRIPTION
Hi Richard, apparently if wrong user details are provided, it won't be the SAML response that contains authentication responses, but the web server itself may also respond with a HTTP/1.1 401 Not Authorized error message. Naturally, that can't be parsed since it is not a SOAP response. Thought this might be useful to check the return code before continuing.
